### PR TITLE
feat: update facebook credential structure

### DIFF
--- a/src/models/project.rs
+++ b/src/models/project.rs
@@ -4,9 +4,25 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Watermark {
+    // Add watermark fields as needed - you'll need to specify the exact structure
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct FacebookCredential {
+    pub app_id: String,
+    pub app_secret: String,
     pub access_token: String,
-    pub page_id: String,
+    pub ad_account_id: String,
+    pub account_suffix: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pixel_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub link_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watermark: Option<Watermark>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/src/repository/project_repository_test.rs
+++ b/src/repository/project_repository_test.rs
@@ -30,8 +30,15 @@ fn create_test_project() -> Project {
     facebook_credentials.insert(
         "test_page".to_string(),
         FacebookCredential {
+            app_id: "test_app_id".to_string(),
+            app_secret: "test_app_secret".to_string(),
             access_token: "test_token".to_string(),
-            page_id: "test_page_id".to_string(),
+            ad_account_id: "test_ad_account_id".to_string(),
+            account_suffix: "test_suffix".to_string(),
+            pixel_id: None,
+            link_url: None,
+            page_id: Some("test_page_id".to_string()),
+            watermark: None,
         },
     );
 


### PR DESCRIPTION
### Problems

This PR updates the FacebookCredential structure in the project model:

- Adds new fields: app_id, app_secret, ad_account_id, account

### Solutions

The solution involves updating the `FacebookCredential` struct in the `project.rs` file and modifying the test project creation in the `project_repository_test.rs` file. Here's a summary of the changes:

1. In `project.rs`:
   - Add a new `Watermark` struct.
   - Update `FacebookCredential` struct with new fields:
     - Add `app_id` and `app_secret`
     - Add `ad_account_id` and `account_suffix`
     - Make `page_id` optional
     - Add optional `pixel_id`, `link_url`, and `watermark` fields

2. In `project_repository_test.rs`:
   - Update the `create_test_project()` function to include the new fields in `FacebookCredential`:
     - Add `app_id` and `app_secret`
     - Add `ad_account_id` and `account_suffix`
     - Make `page_id` optional
     - Set `pixel_id`, `link_url`, and `watermark` to `None`

These changes ensure that the `FacebookCredential` struct and the test project creation are consistent with the new requirements.

### Changes

Here are the main changes:

1. Adds new Watermark struct
2. Expands FacebookCredential struct:
   - Adds app_id and app_secret fields
   - Changes page_id to optional
   - Adds ad_account_id and account_suffix fields
   - Adds optional pixel_id, link_url, and watermark fields
3. Updates test project creation:
   - Includes new required fields in FacebookCredential
   - Sets optional fields to None or Some as appropriate